### PR TITLE
feat: add types to module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ chrome.bat
 certificatecache.json
 archives
 prebuilds
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ certificatecache.json
 Dockerf*
 archives
 prebuilds
+*/tsconfig.tsbuildinfo

--- a/build.js
+++ b/build.js
@@ -157,6 +157,23 @@ const prebuildInstall = async (args) => {
   })
 }
 
+const buildTypes = async () => {
+  return new Promise((resolve, reject) => {
+    const tsc = 'tsc'
+    const proc = spawn(tsc, {
+      cwd: process.cwd(),
+      stdio: [null, 'inherit', 'inherit'],
+      shell: true
+    })
+
+    proc.on('close', (code) => {
+      if (code === 0) resolve(code)
+      else reject(code)
+      console.log(`child process exited with code ${code}`)
+    })
+  })
+}
+
 const execbuild = async (args) => {
   return new Promise((resolve, reject) => {
     const cmakejs = 'cmake-js'
@@ -191,7 +208,7 @@ if (argv.length > 2) {
   switch (argv[2]) {
     case 'prebuild':
       try {
-        prebuild([
+        await prebuild([
           '-t',
           '6',
           '-r',
@@ -229,13 +246,13 @@ if (argv.length > 2) {
         await extractthirdparty()
       } catch (error) {
         console.error('Building binary failed: ', error)
-      
       }
     }
     // eslint-disable-next-line no-fallthrough
     case 'build':
       try {
-        execbuild(['build', ...platformargs])
+        await execbuild(['build', ...platformargs])
+        await buildTypes()
       } catch (error) {
         console.error('Building binary failed: ', error)
         process.exit(1)
@@ -243,7 +260,8 @@ if (argv.length > 2) {
       break
     case 'rebuild':
       try {
-        execbuild(['rebuild', ...platformargs])
+        await execbuild(['rebuild', ...platformargs])
+        await buildTypes()
       } catch (error) {
         console.error('ReBuilding binary failed: ', error)
         process.exit(1)
@@ -251,7 +269,8 @@ if (argv.length > 2) {
       break
     case 'build-debug':
       try {
-        execbuild(['build', '-D', ...platformargs])
+        await execbuild(['build', '-D', ...platformargs])
+        await buildTypes()
       } catch (error) {
         console.error('Building binary failed: ', error)
         process.exit(1)
@@ -259,7 +278,8 @@ if (argv.length > 2) {
       break
     case 'rebuild-debug':
       try {
-        execbuild(['rebuild', '-D', ...platformargs])
+        await execbuild(['rebuild', '-D', ...platformargs])
+        await buildTypes()
       } catch (error) {
         console.error('ReBuilding binary failed: ', error)
         process.exit(1)

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "node": ">=16"
   },
   "type": "module",
+  "types": "./dist/src/webtransport.d.ts",
   "scripts": {
     "start": "node test/echoserver.js",
     "test": "node test/test.js",
-    "install": "node build.js install",
-    "build": "node build.js build",
-    "rebuild": "node build.js rebuild",
-    "rebuild-debug": "node build.js rebuild-debug -D",
-    "build-debug": "node build.js build-debug"
+    "install": "node build.js install && tsc",
+    "build": "node build.js build && tsc",
+    "rebuild": "node build.js rebuild && tsc",
+    "rebuild-debug": "node build.js rebuild-debug -D && tsc",
+    "build-debug": "node build.js build-debug && tsc"
   },
   "repository": {
     "type": "git",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.10",
     "@babel/eslint-parser": "^7.17.0",
+    "@types/node": "^18.11.5",
     "cmake-js": "^6.3.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^7.2.0",
@@ -48,7 +50,8 @@
     "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-standard": "^4.1.0",
     "node-forge": "^1.3.1",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
+    "typescript": "^4.8.4"
   },
   "binary": {
     "napi_versions": [

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "scripts": {
     "start": "node test/echoserver.js",
     "test": "node test/test.js",
-    "install": "node build.js install && tsc",
-    "build": "node build.js build && tsc",
-    "rebuild": "node build.js rebuild && tsc",
-    "rebuild-debug": "node build.js rebuild-debug -D && tsc",
-    "build-debug": "node build.js build-debug && tsc"
+    "install": "node build.js install",
+    "build": "node build.js build",
+    "rebuild": "node build.js rebuild",
+    "rebuild-debug": "node build.js rebuild-debug -D",
+    "build-debug": "node build.js build-debug",
+    "types": "tsc"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -40,23 +40,46 @@ In case of github packages, please add to your `.npmrc` file
 ```
 In this case you need to be authenticated against github.
 
-The package provides prebuild binaries for `windows`, `linux` and `macos` for the platform `x64` and `ia32` (only windows). 
+The package provides prebuild binaries for `windows`, `linux` and `macos` for the platform `x64` and `ia32` (only windows).
 Other platforms may be possible via crosscompiling in the github actions, if someone needs this, PRs are welcome.
 
 Of course you can also build the binary on your system.
 If you are running the compiling install as root, you need to use `--unsafe-perm` as flag.
-Installing the package without prebuild requires a full building environment including clang-9, perl6, python, golang,  ninja-build, icu. See the `Dockerfile` or `Dockerfile.development` for required debian packages. 
-This should work for Windows, linux and Mac OS X. 
+Installing the package without prebuild requires a full building environment including clang-9, perl6, python, golang,  ninja-build, icu. See the `Dockerfile` or `Dockerfile.development` for required debian packages.
+This should work for Windows, linux and Mac OS X.
 (You may want to check out the building dependencies (especially for windows) for BoringSSl, zlib, abseil on their respective websites).
 
-Of course,  PR for patches and for compiling instructions and necessary changes are welcome for all possible environments. 
+Of course,  PR for patches and for compiling instructions and necessary changes are welcome for all possible environments.
 
 ** Warning the build time takes more than 15 minutes, on windows even longer! (Due to the building of the third party libraries). **
 
-In the directory `test` you find a simple echo server code. That answers to a series of WebTransport echos. Furthermore some example browser code and finally a unit test of the library including certificate generation. 
+In the directory `test` you find a simple echo server code. That answers to a series of WebTransport echos. Furthermore some example browser code and finally a unit test of the library including certificate generation.
 
 When testing remember you might need to start chromium based browser with certain flags to accept your http/3 certificate with errors, e.g.:
 ```
 chrome --ignore-certificate-errors-spki-list=FINGERPRINTOFYOURCERTIFICATE --ignore-certificate-errors --v=2 --enable-logging=stderr --origin-to-force-quic-on=192.168.1.50:8080
 ```
 of course replace IP and fingerprint of your certificate accordingly.
+
+## Specification divergence
+
+This module implements parts of the [WebTransport spec](https://datatracker.ietf.org/doc/html/draft-vvv-webtransport-quic-00) but not all of it.
+
+The types from the [W3C Working Draft](https://www.w3.org/TR/webtransport/) have been added to [src/dom.ts] but some fields are commented out.
+
+These fields are unimplemented by this module at this time. Some may be implemented in the future, others are legacy fields that may be removed from the spec. PRs are welcome!
+
+They are:
+
+### WebTransport
+
+* [getStats()](https://www.w3.org/TR/webtransport/#dom-webtransport-getstats)
+* [reliability](https://www.w3.org/TR/webtransport/#dom-webtransport-reliability)
+
+### WebTransportDatagramDuplexStream
+
+* [maxDatagramSize](https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-maxdatagramsize)
+* [incomingMaxAge](https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-incomingmaxage)
+* [outgoingMaxAge](https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-outgoingmaxage)
+* [incomingHighWaterMark](https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-incominghighwatermark)
+* [outgoingHighWaterMark](https://www.w3.org/TR/webtransport/#dom-webtransportdatagramduplexstream-outgoinghighwatermark)

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -31,11 +31,11 @@ export interface WebTransportCloseInfo {
 export interface WebTransportDatagramDuplexStream {
   readable: ReadableStream<Uint8Array>
   writable: WritableStream<Uint8Array>
-  readonly maxDatagramSize: number
-  incomingMaxAge?: number
-  outgoingMaxAge?: number
-  incomingHighWaterMark: number
-  outgoingHighWaterMark: number
+  // readonly maxDatagramSize: number
+  // incomingMaxAge?: number
+  // outgoingMaxAge?: number
+  // incomingHighWaterMark: number
+  // outgoingHighWaterMark: number
 }
 
 export interface WebTransportBidirectionalStream {
@@ -76,9 +76,9 @@ export interface WebTransportOptions {
 }
 
 export interface WebTransport {
-  getStats: () => Promise<WebTransportStats>
+  // getStats: () => Promise<WebTransportStats>
   readonly ready: Promise<void>
-  readonly reliability: WebTransportReliabilityMode
+  // readonly reliability: WebTransportReliabilityMode
   readonly closed: Promise<WebTransportCloseInfo>
   close: (closeInfo?: WebTransportCloseInfo) => void
   readonly datagrams: WebTransportDatagramDuplexStream

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,0 +1,95 @@
+// Types taken from https://www.w3.org/TR/webtransport
+// These can be removed when they are added to the default typescript types
+
+export interface WebTransportDatagramStats {
+  timestamp: number
+  expiredOutgoing: bigint
+  droppedIncoming: bigint
+  lostOutgoing: bigint
+}
+
+export interface WebTransportStats {
+  timestamp: number
+  bytesSent: bigint
+  packetsSent: bigint
+  packetsLost: bigint
+  numOutgoingStreamsCreated: number
+  numIncomingStreamsCreated: number
+  bytesReceived: bigint
+  packetsReceived: bigint
+  smoothedRtt: number
+  rttVariation: number
+  minRtt: number
+  datagrams: WebTransportDatagramStats
+}
+
+export interface WebTransportCloseInfo {
+  closeCode: number
+  reason: string
+}
+
+export interface WebTransportDatagramDuplexStream {
+  readable: ReadableStream<Uint8Array>
+  writable: WritableStream<Uint8Array>
+  readonly maxDatagramSize: number
+  incomingMaxAge?: number
+  outgoingMaxAge?: number
+  incomingHighWaterMark: number
+  outgoingHighWaterMark: number
+}
+
+export interface WebTransportBidirectionalStream {
+  readonly readable: ReadableStream<Uint8Array>
+  readonly writable: WritableStream<Uint8Array>
+}
+
+export interface  WebTransportSendStreamStats {
+  timestamp: number
+  bytesWritten: bigint
+  bytesSent: bigint
+  bytesAcknowledged: bigint
+}
+
+export interface WebTransportSendStream extends WritableStream<Uint8Array> {
+  getStats: () => Promise<WebTransportSendStreamStats>
+}
+
+export interface WebTransportReceiveStreamStats {
+  timestamp: number
+  bytesReceived: bigint
+  bytesRead: bigint
+}
+
+export interface WebTransportReceiveStream extends ReadableStream<Uint8Array> {
+  getStats: () => Promise<WebTransportReceiveStreamStats>
+}
+
+export interface WebTransportHash {
+  algorithm: string
+  value: BufferSource
+}
+
+export interface WebTransportOptions {
+  allowPooling?: boolean
+  requireUnreliable?: boolean
+  serverCertificateHashes?: WebTransportHash[]
+}
+
+export interface WebTransport {
+  getStats: () => Promise<WebTransportStats>
+  readonly ready: Promise<void>
+  readonly reliability: WebTransportReliabilityMode
+  readonly closed: Promise<WebTransportCloseInfo>
+  close: (closeInfo?: WebTransportCloseInfo) => void
+  readonly datagrams: WebTransportDatagramDuplexStream
+
+  createBidirectionalStream: () => Promise<WebTransportBidirectionalStream>
+  /* a ReadableStream of WebTransportBidirectionalStream objects */
+  readonly incomingBidirectionalStreams: ReadableStream<WebTransportBidirectionalStream>
+
+  createUnidirectionalStream: () => Promise<WebTransportSendStream>
+  /* a ReadableStream of WebTransportReceiveStream objects */
+  readonly incomingUnidirectionalStreams: ReadableStream<WebTransportReceiveStream>
+}
+
+export type WebTransportReliabilityMode = 'pending' | 'reliable-only' | 'supports-unreliable'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,133 @@
+import type { WebTransport } from './dom'
+
+/**
+ * Native Http3WTSession counterpart
+ */
+ export interface NativeHttp3WTSession {
+  jsobj: WebTransportSessionEventHandler
+  writeDatagram: (chunk: Uint8Array) => void
+  orderUnidiStream: () => void
+  orderBidiStream: () => void
+  close: (arg: { code: number, reason: string }) => void
+}
+
+/**
+ * Native Http3WTStream counterpart
+ */
+export interface NativeHttp3WTStream {
+  jsobj: WebTransportStreamEventHandler
+  startReading: () => void
+  stopReading: () => void
+  stopSending: (code: number) => void
+  resetStream: (code: number) => void
+  writeChunk: (buf: Uint8Array) => void
+  streamFinal: () => void
+}
+
+export type Purpose = 'StreamRecvSignal' | 'StreamRead' | 'StreamWrite' | 'StreamReset' | 'StreamNetworkFinish'
+export type NetTask = 'stopSending' | 'resetStream' | 'streamFinal'
+
+export interface StreamRecvSignalEvent {
+  object: NativeHttp3WTStream
+  purpose: 'StreamRecvSignal'
+  code: number
+  nettask: NetTask
+}
+
+export interface StreamReadEvent {
+  object: NativeHttp3WTStream
+  purpose: 'StreamRead'
+  data?: Uint8Array
+  fin?: boolean
+}
+
+export interface StreamWriteEvent {
+  object: NativeHttp3WTStream
+  purpose: 'StreamWrite'
+}
+
+export interface StreamResetEvent {
+  object: NativeHttp3WTStream
+  purpose: 'StreamReset'
+}
+
+export interface StreamNetworkFinishEvent {
+  object: NativeHttp3WTStream
+  purpose: 'StreamNetworkFinish'
+  nettask: NetTask
+}
+
+export interface WebTransportStreamEventHandler {
+  onStreamRecvSignal: (evt: StreamRecvSignalEvent) => void
+  onStreamRead: (evt: StreamReadEvent) => void
+  onStreamWrite: (evt: StreamWriteEvent) => void
+  onStreamReset: (evt: StreamResetEvent) => void
+  onStreamNetworkFinish: (evt: StreamNetworkFinishEvent) => void
+}
+
+export interface SessionReadyEvent {
+  object: NativeHttp3WTSession
+  purpose: 'SessionReady'
+}
+
+export interface SessionCloseEvent {
+  object: NativeHttp3WTSession
+  purpose: 'SessionClose'
+  errorcode: number
+  error: string
+}
+
+export interface DatagramReceivedEvent {
+  object: NativeHttp3WTSession
+  purpose: 'DatagramReceived'
+  datagram: Uint8Array
+}
+
+export interface DatagramSendEvent {
+  object: NativeHttp3WTSession
+  purpose: 'DatagramSend'
+}
+
+export interface NewStreamEvent {
+  object: NativeHttp3WTSession
+  purpose: 'Http3WTStreamVisitor'
+  stream: NativeHttp3WTStream
+  transport: object
+  bidirectional: boolean
+  incoming: boolean
+}
+
+export interface WebTransportSessionEventHandler {
+  onReady: (evt: SessionReadyEvent) => void
+  onClose: (evt: SessionCloseEvent) => void
+  onDatagramReceived: (evt: DatagramReceivedEvent) => void
+  onDatagramSend: (evt: DatagramSendEvent) => void
+  onStream: (evt: NewStreamEvent) => void
+  closeHook?: (() => void) | null
+}
+
+export interface ClientConnectedEvent {
+  purpose: 'ClientConnected'
+  success: boolean
+}
+
+export interface ClientWebtransportSupportEvent {
+  purpose: 'ClientWebtransportSupport'
+}
+
+export interface Http3WTSessionVisitorEvent {
+  purpose: 'Http3WTSessionVisitor'
+  session: NativeHttp3WTSession
+}
+
+export interface Http3ClientEventHandler {
+  onClientConnected: (evt: ClientConnectedEvent) => void
+  onClientWebTransportSupport: (evt: ClientWebtransportSupportEvent) => void
+  onHttp3WTSessionVisitor: (evt: Http3WTSessionVisitorEvent) => void
+}
+
+export type WebTransportSessionState = 'connected' | 'closed' | 'failed'
+
+export interface WebTransportSession extends WebTransport {
+  state: WebTransportSessionState
+}

--- a/src/webtransport.js
+++ b/src/webtransport.js
@@ -453,12 +453,7 @@ class Http3WTSession {
         close: () => {
           // do nothing
         }
-      }),
-      maxDatagramSize: 0,
-      incomingMaxAge: 0,
-      outgoingMaxAge: 0,
-      incomingHighWaterMark: 0,
-      outgoingHighWaterMark: 0
+      })
     }
 
     /** @type {Array<(stream: WebTransportBidirectionalStream) => void>} */
@@ -760,33 +755,6 @@ class Http3WTSession {
           throw new Error('unknown purpose Sessioncb')
       }
     } else throw new Error('no purpose Sessioncb')
-  }
-
-  getStats() {
-    return Promise.resolve({
-      timestamp: 0,
-      bytesSent: 0n,
-      packetsSent: 0n,
-      packetsLost: 0n,
-      numOutgoingStreamsCreated: 0,
-      numIncomingStreamsCreated: 0,
-      bytesReceived: 0n,
-      packetsReceived: 0n,
-      smoothedRtt: 0,
-      rttVariation: 0,
-      minRtt: 0,
-      datagrams: {
-        timestamp: 0,
-        expiredOutgoing: 0n,
-        droppedIncoming: 0n,
-        lostOutgoing: 0n
-      }
-    })
-  }
-
-  /** @returns {import('./dom').WebTransportReliabilityMode} */
-  get reliability () {
-    return 'reliable-only'
   }
 }
 
@@ -1123,33 +1091,6 @@ export class WebTransport {
 
   createUnidirectionalStream() {
     return this.sessionint.createUnidirectionalStream()
-  }
-
-  getStats() {
-    return Promise.resolve({
-      timestamp: 0,
-      bytesSent: 0n,
-      packetsSent: 0n,
-      packetsLost: 0n,
-      numOutgoingStreamsCreated: 0,
-      numIncomingStreamsCreated: 0,
-      bytesReceived: 0n,
-      packetsReceived: 0n,
-      smoothedRtt: 0,
-      rttVariation: 0,
-      minRtt: 0,
-      datagrams: {
-        timestamp: 0,
-        expiredOutgoing: 0n,
-        droppedIncoming: 0n,
-        lostOutgoing: 0n
-      }
-    })
-  }
-
-  /** @returns {import('./dom').WebTransportReliabilityMode} */
-  get reliability () {
-    return 'reliable-only'
   }
 }
 

--- a/src/webtransport.js
+++ b/src/webtransport.js
@@ -728,7 +728,6 @@ class Http3WTSession {
    * @param {SessionReadyEvent | SessionCloseEvent | DatagramReceivedEvent | DatagramSendEvent | NewStreamEvent} args
    */
   static callback(args) {
-    console.log('Session callback called', args)
     // console.log('Session callback called', args)
     if (!args || !args.object || !args.object.jsobj)
       throw new Error('Session callback without jsobj')

--- a/src/webtransport.js
+++ b/src/webtransport.js
@@ -1156,7 +1156,7 @@ export class WebTransport {
 
 class Http3EventLoop {
   /** @type {Http3EventLoop | null} */
-  static globalLoop = Http3EventLoop.createGlobalEventLoop()
+  static globalLoop = null
 
   /**
    * @param {*} [args]
@@ -1222,7 +1222,7 @@ class Http3EventLoop {
    */
   static getGlobalEventLoop(object) {
     if (!object) throw new Error('getGlobalEventLoop without reference object')
-    const loop = Http3EventLoop.globalLoop ?? Http3EventLoop.createGlobalEventLoop()
+    const loop = Http3EventLoop.createGlobalEventLoop()
     loop.refObjects.add(new WeakRef(object))
     return loop
   }

--- a/src/webtransport.js
+++ b/src/webtransport.js
@@ -1221,7 +1221,7 @@ class Http3EventLoop {
    */
   static getGlobalEventLoop(object) {
     if (!object) throw new Error('getGlobalEventLoop without reference object')
-    const loop = Http3EventLoop.createGlobalEventLoop()
+    const loop = Http3EventLoop.globalLoop ?? Http3EventLoop.createGlobalEventLoop()
     loop.refObjects.add(new WeakRef(object))
     return loop
   }

--- a/test/certificate.js
+++ b/test/certificate.js
@@ -53,6 +53,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
+// @ts-expect-error node-forge has no types and @types/node-forge do not include oids
 import forge from 'node-forge'
 import { webcrypto as crypto } from 'crypto'
 import { X509Certificate } from 'crypto'
@@ -62,7 +63,7 @@ const { pki, asn1, oids } = forge
 /**
  * Converts an X.509 subject or issuer to an ASN.1 RDNSequence.
  *
- * @param obj the subject or issuer (distinguished name).
+ * @param {any} obj the subject or issuer (distinguished name).
  *
  * @return the ASN.1 RDNSequence.
  */
@@ -110,18 +111,17 @@ function _dnToAsn1(obj) {
   return rval
 }
 
+const jan_1_1950 = new Date('1950-01-01T00:00:00Z')
+const jan_1_2050 = new Date('2050-01-01T00:00:00Z')
 // taken from node-forge almost not modified
 /**
  * Converts a Date object to ASN.1
  * Handles the different format before and after 1st January 2050
  *
- * @param date date object.
+ * @param {Date} date date object.
  *
  * @return the ASN.1 object representing the date.
  */
-
-const jan_1_1950 = new Date('1950-01-01T00:00:00Z')
-const jan_1_2050 = new Date('2050-01-01T00:00:00Z')
 function _dateToAsn1(date) {
   if (date >= jan_1_1950 && date < jan_1_2050) {
     return asn1.create(
@@ -144,8 +144,8 @@ function _dateToAsn1(date) {
 /**
  * Convert signature parameters object to ASN.1
  *
- * @param {String} oid Signature algorithm OID
- * @param params The signature parametrs object
+ * @param {string} oid Signature algorithm OID
+ * @param {any} params The signature parameters object
  * @return ASN.1 object representing signature parameters
  */
 function _signatureParametersToAsn1(oid, params) {
@@ -217,7 +217,7 @@ function _signatureParametersToAsn1(oid, params) {
 /**
  * Gets the ASN.1 TBSCertificate part of an X.509v3 certificate.
  *
- * @param cert the certificate.
+ * @param {any} cert the certificate.
  *
  * @return the asn1 TBSCertificate.
  */
@@ -319,6 +319,10 @@ function getTBSCertificate(cert) {
 // because serial numbers use ones' complement notation
 // this RFC in section 4.1.2.2 requires serial numbers to be positive
 // http://www.ietf.org/rfc/rfc5280.txt
+/**
+ * @param {string} hexString
+ * @returns
+ */
 function toPositiveHex(hexString) {
   let mostSiginficativeHexAsInt = parseInt(hexString[0], 16)
   if (mostSiginficativeHexAsInt < 8) {
@@ -330,6 +334,18 @@ function toPositiveHex(hexString) {
 }
 
 // the next is an edit of the selfsigned function reduced to the function necessary for webtransport
+/**
+ * @typedef {object} Certificate
+ * @property {string} public
+ * @property {string} private
+ * @property {string} cert
+ * @property {Uint8Array} hash
+ * @property {string} fingerprint
+ *
+ * @param {*} attrs
+ * @param {*} options
+ * @returns {Promise<Certificate | null>}
+ */
 export async function generateWebTransportCertificate(attrs, options) {
   try {
     let keyPair = await crypto.subtle.generateKey(

--- a/test/echoclient.js
+++ b/test/echoclient.js
@@ -5,16 +5,22 @@
 import { echoTestsConnection } from './testsuite.js'
 import { WebTransport  } from '../src/webtransport.js'
 
+/**
+ * @param {{ hostname: string, port: number }} args
+ * @param {{ serverCertificateHashes: Array<{ algorithm: string, value: string }> }} hashes
+ */
 async function startClientTests(args, hashes) {
   const url = 'https://' + args.hostname + ':' + args.port + '/echo'
   console.log('startconnection')
-  const hashargs = { ...hashes }
-  hashargs.serverCertificateHashes = hashes.serverCertificateHashes.map(
-    (el) => ({
-      algorithm: el.algorithm,
-      value: Buffer.from(el.value.split(':').map((el) => parseInt(el, 16)))
-    })
-  )
+  const hashargs = {
+    ...hashes,
+    serverCertificateHashes: hashes.serverCertificateHashes.map(
+      (el) => ({
+        algorithm: el.algorithm,
+        value: Buffer.from(el.value.split(':').map((el) => parseInt(el, 16)))
+      })
+    )
+  }
   // eslint-disable-next-line no-undef
   console.log('hashagrs', hashargs)
   const transport = new WebTransport(url, hashargs)

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,10 @@ async function run() {
     days: 13
   })
 
+  if (certificate == null) {
+    throw new Error('Certificate generation failed')
+  }
+
   console.log('start Http3Server and startup echo tests')
   // now ramp up the server
   const http3server = new Http3Server({
@@ -52,6 +56,7 @@ async function run() {
 
   const url = 'https://127.0.0.1:8080/echo'
 
+  /** @type {import('../src/dom').WebTransport | null} */
   let client = new WebTransport(url, {
     serverCertificateHashes: [{ algorithm: 'sha-256', value: certificate.hash }]
   })

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/**
+ * @param {import('../src/dom').WebTransport} session
+ */
 export async function incomingBidirectionalEchoTest(session) {
   try {
     const bidiReader = session.incomingBidirectionalStreams.getReader()
@@ -24,6 +27,9 @@ export async function incomingBidirectionalEchoTest(session) {
   }
 }
 
+/**
+ * @param {import('../src/dom').WebTransport} session
+ */
 export async function outgoingBidirectionalEchoTest(session) {
   try {
     const mybidistream = await session.createBidirectionalStream()
@@ -33,6 +39,9 @@ export async function outgoingBidirectionalEchoTest(session) {
   }
 }
 
+/**
+ * @param {import('../src/dom').WebTransport} session
+ */
 export async function unidirectionalEchoTest(session) {
   try {
     const unidiReader = session.incomingUnidirectionalStreams.getReader()
@@ -56,6 +65,9 @@ export async function unidirectionalEchoTest(session) {
   }
 }
 
+/**
+ * @param {import('../src/dom').WebTransport} session
+ */
 export async function datagramEchoTest(session) {
   try {
     session.datagrams.readable.pipeTo(session.datagrams.writable)
@@ -64,6 +76,9 @@ export async function datagramEchoTest(session) {
   }
 }
 
+/**
+ * @param {import('../src/webtransport').Http3Server} server
+ */
 export async function runEchoServer(server) {
   try {
     const sessionStream = await server.sessionStream('/echo')
@@ -99,6 +114,10 @@ export async function runEchoServer(server) {
   }
 }
 
+/**
+ * @param {ArrayLike<any>} array1
+ * @param {ArrayLike<any>} array2
+ */
 function testArraysEqual(array1, array2) {
   if (array1.length !== array2.length)
     throw new Error('Array not equal in length')
@@ -107,6 +126,9 @@ function testArraysEqual(array1, array2) {
   }
 }
 
+/**
+ * @param {import('../src/dom').WebTransport} transport
+ */
 export async function echoTestsConnection(transport) {
   // some echo tests for testing the webtransport library, not for production
   const stream = await transport.createBidirectionalStream()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+      "strict": true,
+      // project options
+      "outDir": "dist",
+      "allowJs": true,
+      "checkJs": true,
+      "target": "ES2020",
+      "module": "ES2022",
+      "lib": ["ES2021", "ES2021.Promise", "ES2021.String", "ES2020.BigInt", "DOM", "DOM.Iterable"],
+      "noEmit": false,
+      "noEmitOnError": true,
+      "emitDeclarationOnly": true,
+      "declaration": true,
+      "declarationMap": true,
+      "incremental": true,
+      "composite": true,
+      "isolatedModules": true,
+      "removeComments": false,
+      "sourceMap": true,
+      // module resolution
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      // linter checks
+      "noImplicitReturns": false,
+      "noFallthroughCasesInSwitch": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": false,
+      // advanced
+      "importsNotUsedAsValues": "error",
+      "forceConsistentCasingInFileNames": true,
+      "skipLibCheck": true,
+      "stripInternal": true,
+      "resolveJsonModule": true
+  },
+  "include": [
+      "src",
+      "test"
+  ]
+}


### PR DESCRIPTION
* Generate types from JSDoc
* Adds `src/dom.ts` - types take from the WebTransport spec
* Adds `src/types.ts` - interfaces used by `src/webtransport.js`
* Adds types to `src/webtransport.js` and all tests
* Exposes WebTransport spec types to hide internal implementation details

Some things to consider:

* Adds functions and properties to conform to the spec more closely, mostly around stats
* Where these stats are not available they return `0` or `0n` - I figure these can be filled in at a later date
* `number` is used for `DOMHighResTimeStamp` as it is a `double`
* `bigint` is used for `unsigned long long` as it can overflow a `number`
* I can't see any of the `unsigned long long` fields used in Chrome's `WebTransport` implementation so I'm unsure if `bigint` is correct or if `number` will do, we'll probably have to wait and see what's implemented

I performed some small refactorings:

* `Http3Client` has had it's handler methods split out of `customCallback` as it seemed consistent with the other classes
* `Http3EventLoop.globalLoop` is created as a local variable otherwise you have to null guard on every `Http3EventLoop.globalLoop` access
* In order to type instance fields it's sometimes necessary to set them in the constructor
* In some places it was necessary to add additional null-guarding

Improvements we may wish to make:

* The `webtransport.js` file is quite large, splitting the classes out into separate files would aid readability and testing
* The whole of the `/src` dir is bundled into the release, consider moving `.js` into `/lib` and keeping `/src` for `.cc`/`.h` files and only including `/lib`
* Does the `platform` dir need to be included in the release too?
* A lot of code could be simplified by reusing other modules - `p-defer` instead of having `this.fooResolve` and `this.fooReject` everywhere for example
* Error handling seems quite limited - for example waiting for a client session to be ready hangs forever if there's an error connecting
* `console.log` is used in the non-test code which makes controlling output hard
* There are random delays in places, starting a server then setting a timeout before connecting to it, for example - better to use events like `"listening"` same as the node core `http` module

Fixes: #93