### PR TITLE
chore: add linter script and run it in CI

### DIFF
--- a/.github/workflows/libtest-linux.yml
+++ b/.github/workflows/libtest-linux.yml
@@ -25,19 +25,22 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
-          submodules: recursive    
-        
+          submodules: recursive
+
       - name: Set up NodeJS
         uses: actions/setup-node@v1
         with:
           node-version: 16
-        
+
       - name: Install dependencies
         run: npm install
 
       - name: Build library
         run: npm run build
-        
+
+      - name: Lint files
+        run: npm run lint
+
       - name: Run unit tests
         run: NODE_ENV=production npm test
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,8 @@
-
 /**
  * @template {unknown} T
  * @returns {import('./types').Deferred<T>}
  */
-export function defer () {
+export function defer() {
   /** @type {(value?: T) => void} */
   let res = () => {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,12 @@
         "@babel/core": "^7.17.10",
         "@babel/eslint-parser": "^7.17.0",
         "@types/chai": "^4.3.3",
+        "@types/dirty-chai": "^2.0.2",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.11.5",
         "chai": "^4.3.6",
         "cmake-js": "^6.3.2",
+        "dirty-chai": "^2.0.1",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^7.2.0",
         "eslint-config-standard": "^16.0.2",
@@ -606,6 +608,25 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
       "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
       "dev": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/dirty-chai": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dirty-chai/-/dirty-chai-2.0.2.tgz",
+      "integrity": "sha512-BruwIN/UQEU0ePghxEX+OyjngpOfOUKJQh3cmfeq2h2Su/g001iljVi3+Y2y2EFp3IPgjf4sMrRU33Hxv1FUqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/chai-as-promised": "*"
+      }
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1408,6 +1429,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dirty-chai": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": ">=2.2.1 <5"
       }
     },
     "node_modules/doctrine": {
@@ -5053,6 +5083,25 @@
       "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
       "dev": true
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
+    "@types/dirty-chai": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/dirty-chai/-/dirty-chai-2.0.2.tgz",
+      "integrity": "sha512-BruwIN/UQEU0ePghxEX+OyjngpOfOUKJQh3cmfeq2h2Su/g001iljVi3+Y2y2EFp3IPgjf4sMrRU33Hxv1FUqw==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/chai-as-promised": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -5644,6 +5693,13 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
+    },
+    "dirty-chai": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
+      "dev": true,
+      "requires": {}
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "rebuild": "node build.js rebuild",
     "rebuild-debug": "node build.js rebuild-debug -D",
     "build-debug": "node build.js build-debug",
-    "types": "tsc"
+    "types": "tsc",
+    "lint": "eslint lib test"
   },
   "repository": {
     "type": "git",
@@ -42,10 +43,12 @@
     "@babel/core": "^7.17.10",
     "@babel/eslint-parser": "^7.17.0",
     "@types/chai": "^4.3.3",
+    "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.5",
     "chai": "^4.3.6",
     "cmake-js": "^6.3.2",
+    "dirty-chai": "^2.0.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-config-standard": "^16.0.2",

--- a/test/bidirectional-streams.spec.js
+++ b/test/bidirectional-streams.spec.js
@@ -1,8 +1,9 @@
-/* eslint-disable no-undef */
+/* eslint-env mocha */
+
 import { createServer } from './fixtures/server.js'
 import { getReaderValue } from './fixtures/reader-value.js'
 import { WebTransport } from '../lib/index.js'
-import { expect } from 'chai'
+import { expect } from './fixtures/chai.js'
 import { readStream } from './fixtures/read-stream.js'
 import { writeStream } from './fixtures/write-stream.js'
 import { defer } from '../lib/utils.js'

--- a/test/datagrams.spec.js
+++ b/test/datagrams.spec.js
@@ -1,8 +1,9 @@
-/* eslint-disable no-undef */
+/* eslint-env mocha */
+
 import { createServer } from './fixtures/server.js'
 import { getReaderValue } from './fixtures/reader-value.js'
 import { WebTransport } from '../lib/index.js'
-import { expect } from 'chai'
+import { expect } from './fixtures/chai.js'
 import { readStream } from './fixtures/read-stream.js'
 import { writeStream } from './fixtures/write-stream.js'
 import { defer } from '../lib/utils.js'

--- a/test/event-loop.spec.js
+++ b/test/event-loop.spec.js
@@ -1,8 +1,9 @@
-/* eslint-disable no-undef */
-import { expect } from 'chai'
+/* eslint-env mocha */
+
+import { expect } from './fixtures/chai.js'
 import { Http3EventLoop } from '../lib/event-loop.js'
 
-describe('event-loop', () => {
+describe.skip('event-loop', () => {
   beforeEach(() => {
     if (Http3EventLoop.globalLoop != null) {
       // shut down loop, otherwise we have to wait for
@@ -12,12 +13,12 @@ describe('event-loop', () => {
   })
 
   it('should start and stop the event loop', () => {
-    expect(Http3EventLoop.globalLoop).to.be.null
+    expect(Http3EventLoop.globalLoop).to.be.null()
 
     Http3EventLoop.createGlobalEventLoop()
-    expect(Http3EventLoop.globalLoop).to.not.be.null
+    expect(Http3EventLoop.globalLoop).to.not.be.null()
 
     Http3EventLoop.globalLoop?.shutdownEventLoop()
-    expect(Http3EventLoop.globalLoop).to.be.null
+    expect(Http3EventLoop.globalLoop).to.be.null()
   })
 })

--- a/test/fixtures/certificate.js
+++ b/test/fixtures/certificate.js
@@ -55,8 +55,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
 // @ts-expect-error node-forge has no types and @types/node-forge do not include oids
 import forge from 'node-forge'
-import { webcrypto as crypto } from 'crypto'
-import { X509Certificate } from 'crypto'
+import { webcrypto as crypto, X509Certificate } from 'crypto'
 
 const { pki, asn1, oids } = forge
 // taken from node-forge
@@ -111,8 +110,8 @@ function _dnToAsn1(obj) {
   return rval
 }
 
-const jan_1_1950 = new Date('1950-01-01T00:00:00Z')
-const jan_1_2050 = new Date('2050-01-01T00:00:00Z')
+const jan_1_1950 = new Date('1950-01-01T00:00:00Z') // eslint-disable-line camelcase
+const jan_1_2050 = new Date('2050-01-01T00:00:00Z') // eslint-disable-line camelcase
 // taken from node-forge almost not modified
 /**
  * Converts a Date object to ASN.1
@@ -123,6 +122,7 @@ const jan_1_2050 = new Date('2050-01-01T00:00:00Z')
  * @return the ASN.1 object representing the date.
  */
 function _dateToAsn1(date) {
+  // eslint-disable-next-line camelcase
   if (date >= jan_1_1950 && date < jan_1_2050) {
     return asn1.create(
       asn1.Class.UNIVERSAL,
@@ -149,10 +149,10 @@ function _dateToAsn1(date) {
  * @return ASN.1 object representing signature parameters
  */
 function _signatureParametersToAsn1(oid, params) {
+  const parts = []
+
   switch (oid) {
     case oids['RSASSA-PSS']:
-      const parts = []
-
       if (params.hash.algorithmOid !== undefined) {
         parts.push(
           asn1.create(asn1.Class.CONTEXT_SPECIFIC, 0, true, [
@@ -348,7 +348,7 @@ function toPositiveHex(hexString) {
  */
 export async function generateWebTransportCertificate(attrs, options) {
   try {
-    let keyPair = await crypto.subtle.generateKey(
+    const keyPair = await crypto.subtle.generateKey(
       {
         name: 'ECDSA',
         namedCurve: 'P-256'
@@ -371,7 +371,7 @@ export async function generateWebTransportCertificate(attrs, options) {
     cert.setSubject(attrs)
     cert.setIssuer(attrs)
 
-    let privateKey = crypto.subtle.exportKey('pkcs8', keyPair.privateKey)
+    const privateKey = crypto.subtle.exportKey('pkcs8', keyPair.privateKey)
     const publicKey = (cert.publicKey = await crypto.subtle.exportKey(
       'spki',
       keyPair.publicKey
@@ -408,7 +408,7 @@ export async function generateWebTransportCertificate(attrs, options) {
     oids['1.2.840.10045.4.3.2'] = 'ecdsa-with-sha256'
     oids['ecdsa-with-sha256'] = '1.2.840.10045.4.3.2'
 
-    cert.siginfo.algorithmOid = cert.signatureOid = '1.2.840.10045.4.3.2' //'ecdsa-with-sha256'
+    cert.siginfo.algorithmOid = cert.signatureOid = '1.2.840.10045.4.3.2' // 'ecdsa-with-sha256'
 
     cert.tbsCertificate = getTBSCertificate(cert)
     const encoded = Buffer.from(

--- a/test/fixtures/chai.js
+++ b/test/fixtures/chai.js
@@ -1,0 +1,6 @@
+import chai from 'chai'
+import dirtyChai from 'dirty-chai'
+
+chai.use(dirtyChai)
+
+export const expect = chai.expect

--- a/test/fixtures/reader-value.js
+++ b/test/fixtures/reader-value.js
@@ -1,10 +1,9 @@
-
 /**
  * @template T
  * @param {ReadableStream<T>} readableStream
  * @returns {Promise<T>}
  */
-export async function getReaderValue (readableStream) {
+export async function getReaderValue(readableStream) {
   const reader = readableStream.getReader()
 
   try {

--- a/test/fixtures/write-stream.js
+++ b/test/fixtures/write-stream.js
@@ -1,4 +1,3 @@
-
 /**
  * Write contents to a stream and close it
  *
@@ -7,7 +6,7 @@
  * @param {T[]} input
  * @returns
  */
- export async function writeStream (writable, input) {
+export async function writeStream(writable, input) {
   const writer = writable.getWriter()
 
   for (const buf of input) {

--- a/test/suite.specoff.js
+++ b/test/suite.specoff.js
@@ -1,9 +1,0 @@
-import { Http3EventLoop } from '../lib/event-loop.js'
-
-after(async () => {
-  if (Http3EventLoop.globalLoop != null) {
-    // shut down loop, otherwise we have to wait for
-    // it to time out which takes a long time.
-    Http3EventLoop.globalLoop.shutdownEventLoop()
-  }
-})

--- a/test/unidirectional-streams.spec.js
+++ b/test/unidirectional-streams.spec.js
@@ -1,4 +1,5 @@
-/* eslint-disable no-undef */
+/* eslint-env mocha */
+
 import { createServer } from './fixtures/server.js'
 import { getReaderValue } from './fixtures/reader-value.js'
 import { WebTransport } from '../lib/index.js'


### PR DESCRIPTION
Follow up from https://github.com/fails-components/webtransport/pull/102#discussion_r1010444739

* Adds a `"lint"` npm script that runs `eslint` against the `lib` and `test` directories.
* Adds dirty chai to enable `expect(foo).to.be.true()`-style assertions as eslint objects to `expect(foo).to.be.true`
* Runs linting in CI on linux
* Fixes all linting issues
* Skips the event-loop tests instead of renaming the file
* Removes the `after` that stops the event loop instead of renaming the file
* Adds the `eslint-env moch` directive to each test file instead of turning off the `no-undefined` rule