### PR TITLE
fix: export http3 server init type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ import { Http3EventLoop } from './event-loop.js'
  *
  * Public API
  * @typedef {import('./types').WebTransportSession} WebTransportSession
+ * @typedef {import('./types').Http3ServerInit} Http3ServerInit
  */
 
 export function testcheck() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,6 +11,7 @@ import { defer } from './utils.js'
  * @typedef {import('./types').Http3ServerEventHandler} Http3ServerEventHandler
  * @typedef {import('./types').Http3WTServerSessionVisitorEvent} Http3WTServerSessionVisitorEvent
  * @typedef {import('./types').ServerStatusEvent} ServerStatusEvent
+ * @typedef {import('./types').Http3ServerInit} Http3ServerInit
  */
 
 /**
@@ -19,7 +20,7 @@ import { defer } from './utils.js'
 export class Http3Server extends Http3WebTransport {
   /**
    *
-   * @param {*} args
+   * @param {Http3ServerInit} args
    */
   constructor(args) {
     super(args, 'server')

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,3 +171,11 @@ export type WebTransportSessionState = 'connected' | 'closed' | 'failed'
 export interface WebTransportSession extends WebTransport {
   state: WebTransportSessionState
 }
+
+export interface Http3ServerInit {
+  port: number
+  host: string
+  secret: string
+  cert: string
+  privKey: string
+}


### PR DESCRIPTION
Adds a type for the args you can pass to the http3server constructor and exports it from the module