### PR TITLE
fix: build types before publish

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -11,14 +11,14 @@ on:
   workflow_dispatch:
     inputs:
       logLevel:
-        description: 'Log level'     
+        description: 'Log level'
         required: true
         default: 'warning'
       tags:
         description: 'Testing node.js package publish workflow'
-        required: true 
+        required: true
         type: string
-  
+
 jobs:
 # version check
   version-check:
@@ -43,7 +43,7 @@ jobs:
       - name: Check if version has been updated
         id: check
         uses: EndBug/version-check@v1
-        with: 
+        with:
          diff-search: true
 
       - name: Log when changed
@@ -55,7 +55,7 @@ jobs:
   prebuild:
     needs: version-check
     strategy:
-      matrix: 
+      matrix:
         os: [ubuntu-latest, windows-2019, macos-latest ]
         arch: [x64]
         include:
@@ -87,13 +87,13 @@ jobs:
     # modified snippet from https://github.com/Homebrew/discussions/discussions/2843
      - name: Install icu for Mac Arm cross compile
        if: matrix.arch == 'arm64' && matrix.os == 'macos-latest'
-       run: | 
-          mkdir -p ../armhomebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C ../armhomebrew 
+       run: |
+          mkdir -p ../armhomebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C ../armhomebrew
           echo "Step1 finished"
           #../armhomebrew/bin/brew fetch --force --bottle-tag=arm64_big_sur icu4c | grep "Downloaded to"
           response=$(../armhomebrew/bin/brew fetch --force --bottle-tag=arm64_big_sur icu4c | grep "Downloaded to")
           echo "Step2 finished with response $response"
-          parsed=($response)  
+          parsed=($response)
           echo "Step3 install ${parsed[2]}"
           ../armhomebrew/bin/brew install ${parsed[2]}
           echo "Step4"
@@ -113,7 +113,7 @@ jobs:
 
      - name: Prebuild
        if: needs.version-check.outputs.changed == 'true'
-       env: 
+       env:
          BUILDARCH: ${{ matrix.arch }}
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          LOCALHOMEWBREWICU: ${{ env.LOCALHOMEWBREWICU }}
@@ -123,7 +123,7 @@ jobs:
 #  prebuild-cross:
 #    needs: version-check
 #    strategy:
-#      matrix: 
+#      matrix:
 #        arch: [x64]
 #    runs-on: ubuntu-latest
 #    permissions:
@@ -146,10 +146,10 @@ jobs:
 #
 #      - name: Prebuild
 #        if: needs.version-check.outputs.changed == 'true'
-#        env: 
+#        env:
 #          BUILDARCH: ${{ matrix.arch }}
 #          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run:  docker run --rm -v ${PWD}:/app -e BUILDARCH=${{ matrix.arch }} -e GH_TOKEN= ${{ secrets.GITHUB_TOKEN }} ghcr.io/prebuild/linux-${{ matrix.arch }} node build.js prebuild 
+#        run:  docker run --rm -v ${PWD}:/app -e BUILDARCH=${{ matrix.arch }} -e GH_TOKEN= ${{ secrets.GITHUB_TOKEN }} ghcr.io/prebuild/linux-${{ matrix.arch }} node build.js prebuild
 
 # steps for github
   publish-gpr:
@@ -172,6 +172,9 @@ jobs:
       - name: Install
         if: needs.version-check.outputs.changed == 'true'
         run: npm ci --ignore-scripts=true
+
+      - name: Build types
+        run: npm run types
 
       - run: npm publish --tag stable
         if: ${{ needs.version-check.outputs.changed == 'true' && github.ref == 'refs/heads/master' }}
@@ -210,6 +213,9 @@ jobs:
       - name: Install
         if: needs.version-check.outputs.changed == 'true'
         run: npm ci --ignore-scripts=true
+
+      - name: Build types
+        run: npm run types
 
       - run: npm publish --tag stable
         if: ${{ needs.version-check.outputs.changed == 'true' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
The `dist` folder is missing in versions published since #94 was merged - it needs to be built before publishing in order to be included in the tarball published to npm so I've added a `Build types` step to the npm and github publish jobs after install but before publish.

This might be better in the `prebuild` subcommand in `build.js`?  I'm not sure, we don't want to end up building types over and over again.