### PR TITLE
Remember pending read when paused

### DIFF
--- a/src/http3wtstreamvisitor.cc
+++ b/src/http3wtstreamvisitor.cc
@@ -69,7 +69,10 @@ namespace quic
     void Http3WTStream::doCanRead()
     {
         if (pause_reading_)
+        {
+            can_read_pending_ = true;
             return; // back pressure folks!
+        }
         // first figure out if we have readable data
         size_t readable = stream_->ReadableBytes();
         // ok create a string obj to hold the data

--- a/src/http3wtstreamvisitor.h
+++ b/src/http3wtstreamvisitor.h
@@ -93,8 +93,9 @@ namespace quic
         void tryRead()
         {
             pause_reading_ = false;
-            if (stream_ && stream_->ReadableBytes() > 0)
+            if (stream_ && ((stream_->ReadableBytes() > 0) || can_read_pending_))
             {
+                can_read_pending_ = false;
                 doCanRead();
             }
         }
@@ -209,6 +210,7 @@ namespace quic
         bool fin_was_sent_ = false;
         bool stop_sending_received_ = false;
         bool pause_reading_ = false;
+        bool can_read_pending_ = false;
         std::deque<WChunks> chunks_;
     };
 


### PR DESCRIPTION
Without this, because we can only check number of readable bytes, we miss a FIN that is received while paused.

You can see quiche regards having a FIN as notifiable here:

https://github.com/google/quiche/blob/main/quiche/quic/core/http/web_transport_stream_adapter.cc#L96

I see this happen occasionally when transferring lots of data and the stream ends while it's "paused"