### PR TITLE
fix: pin typescript to 4.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mocha": "^10.1.0",
     "node-forge": "^1.3.1",
     "prettier": "^2.4.1",
-    "typescript": "^4.8.4"
+    "typescript": "4.8.4"
   },
   "binary": {
     "napi_versions": [


### PR DESCRIPTION
A recent release of TypeScript has updated the types to make the `Readable` and `Writable` generics a union with `ArrayBuffer`.  This is a mistake and breaks the build, so pin TypeScript to an earlier version that works.