### PR TITLE
Restrict the list of files published to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,10 @@
     "napi_versions": [
       6
     ]
-  }
+  },
+  "files": [
+    "build/",
+    "lib/",
+    "dist/lib/"
+  ]
 }


### PR DESCRIPTION
Before:

```
└── webtransport
    ├── build
    │   └── Release
    ├── dist
    │   ├── lib
    │   └── test
    │       └── fixtures
    ├── lib
    ├── platform
    │   ├── icufix
    │   ├── net
    │   │   └── quiche
    │   │       └── common
    │   │           └── platform
    │   │               └── impl
    │   ├── quiche
    │   │   └── quic
    │   │       └── core
    │   │           └── io
    │   └── quiche_platform_impl
    ├── src
    └── test
        └── fixtures
```

After:

```
└── webtransport
    ├── build
    │   └── Release
    ├── dist
    │   └── lib
    └── lib
```

Reference: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files

I think I've included all necessary files, but do not hesitate to check with `npm pack`.