### PR TITLE
docs: fix homepage link in package.json

### DIFF
--- a/main/package.json
+++ b/main/package.json
@@ -43,7 +43,7 @@
   "bugs": {
     "url": "https://github.com/fails-components/webtransport/issues"
   },
-  "homepage": "https://github.com/fails-components/webtransport/main/#readme",
+  "homepage": "https://github.com/fails-components/webtransport/tree/master/main#readme",
   "dependencies": {
     "@types/debug": "^4.1.7",
     "bindings": "^1.5.0",


### PR DESCRIPTION
The homepage link on the [npm page](https://www.npmjs.com/package/@fails-components/webtransport) for this module is broken, so update it to point to the right place.