### PR TITLE
fix: check closed status of socket during callbacks

### DIFF
--- a/transports/http3-quiche/lib/socket.js
+++ b/transports/http3-quiche/lib/socket.js
@@ -85,6 +85,10 @@ export class Http3WebTransportSocket {
   }
 
   doProcessBufferedChlos() {
+    if (this.closed) {
+      return
+    }
+
     this.cobj.processBufferedChlos()
     this.chlosSched = false
   }
@@ -110,6 +114,10 @@ export class Http3WebTransportSocket {
   }
 
   packetSendCB() {
+    if (this.closed) {
+      return
+    }
+
     // @ts-ignore
     if (this.socketInt.getSendQueueCount() === 0 && this.blocked) {
       this.cobj.onCanWrite()


### PR DESCRIPTION
Sometimes calling `getSendQueueCount` can cause an internal crash in the `dgram` module.

I think it may be because packets are being sent during server shutdown - guarding on the `this.closed` property similar to the `sendPacket` method avoids the crash.

```
TypeError: Cannot read properties of null (reading 'getSendQueueCount')
    at Socket.getSendQueueCount (node:dgram:995:36)
    at Http3WebTransportClientSocket.packetSendCB (file:///Users/alex/Documents/Workspaces/libp2p/js-libp2p-webtransport-listener/node_modules/@fails-components/webtransport-transport-http3-quiche/lib/socket.js:118:24)
    at processTicksAndRejections (node:internal/process/task_queues:82:21)
```