### PR TITLE
fix: test that quicheLogVerbose is a number

### DIFF
--- a/transports/http3-quiche/src/librarymain.cc
+++ b/transports/http3-quiche/src/librarymain.cc
@@ -38,7 +38,7 @@ namespace quic
       }
 
       quiche_cmd_line.push_back(std::string("-v"));
-      if (lobj.Has("quicheLogVerbose") && lobj.Get("quicheLogVerbose").IsFunction())
+      if (lobj.Has("quicheLogVerbose") && lobj.Get("quicheLogVerbose").IsNumber())
       {
         Napi::Value verboseValue = (lobj).Get("quicheLogVerbose");
         quiche_cmd_line.push_back(verboseValue.ToString().Utf8Value());


### PR DESCRIPTION
According to the [types](https://github.com/fails-components/webtransport/blob/master/main/lib/types.ts#L272) `quicheLogVerbose` when passed as an option should be a number, the test here asserts it's a function, so it's not possible to enable verbose quiche logging.