### PR TITLE
fix: constrain quicheLogVerbose value

### DIFF
--- a/main/lib/types.ts
+++ b/main/lib/types.ts
@@ -266,10 +266,17 @@ export interface WebTransportSessionImpl extends WebTransportSession {
   state: WebTransportSessionState
 }
 
+export type QUICHE_LOG_OFF = -1
+export type QUICHE_LOG_INFO = 0
+export type QUICHE_LOG_WARNING = 1
+export type QUICHE_LOG_ERROR = 2
+export type QUICHE_LOG_FATAL = 3
+export type QUICHE_LOG = QUICHE_LOG_OFF | QUICHE_LOG_INFO | QUICHE_LOG_WARNING | QUICHE_LOG_ERROR | QUICHE_LOG_FATAL
+
 export interface HttpWebTransportInit extends WebTransportOptions {
   host: string
   port: string | number
-  quicheLogVerbose?: 1 | 2 | 3
+  quicheLogVerbose?: QUICHE_LOG
   forceIpv6?: boolean
   localPort?: number
 }

--- a/main/lib/types.ts
+++ b/main/lib/types.ts
@@ -269,7 +269,7 @@ export interface WebTransportSessionImpl extends WebTransportSession {
 export interface HttpWebTransportInit extends WebTransportOptions {
   host: string
   port: string | number
-  quicheLogVerbose?: number
+  quicheLogVerbose?: 1 | 2 | 3
   forceIpv6?: boolean
   localPort?: number
 }

--- a/transports/http3-quiche/lib/index.js
+++ b/transports/http3-quiche/lib/index.js
@@ -30,7 +30,7 @@ export const quicheInit = wtrouter.quicheInit
 let quicheInited = false
 
 /**
- * @param {{quicheLogVerbose?: Number, path?: string}} [args]
+ * @param {{quicheLogVerbose?: 1 | 2 | 3, path?: string}} [args]
  */
 export const checkQuicheInit = function (args) {
   if (!quicheInited) {

--- a/transports/http3-quiche/lib/index.js
+++ b/transports/http3-quiche/lib/index.js
@@ -5,6 +5,10 @@ import * as url from 'url'
 import { arch, platform } from 'node:process'
 import { logger } from './utils.js'
 
+/**
+ * @typedef {import('./types.js').QUICHE_LOG} QUICHE_LOG
+ */
+
 const log = logger(`webtransport:native(${process?.pid})`)
 
 const binplatform = platform + '_' + arch
@@ -30,7 +34,7 @@ export const quicheInit = wtrouter.quicheInit
 let quicheInited = false
 
 /**
- * @param {{quicheLogVerbose?: 1 | 2 | 3, path?: string}} [args]
+ * @param {{quicheLogVerbose?: QUICHE_LOG, path?: string}} [args]
  */
 export const checkQuicheInit = function (args) {
   if (!quicheInited) {

--- a/transports/http3-quiche/lib/types.ts
+++ b/transports/http3-quiche/lib/types.ts
@@ -19,8 +19,7 @@ export interface UDPServerSocketSend {
   export interface HttpWebTransportInit extends WebTransportOptions {
     host: string
     port: string | number
-    quicheLogVerbose?: number
+    quicheLogVerbose?: 1 | 2 | 3
     forceIpv6?: boolean
     localPort?: number
   }
-  

--- a/transports/http3-quiche/lib/types.ts
+++ b/transports/http3-quiche/lib/types.ts
@@ -16,10 +16,17 @@ export interface UDPServerSocketSend {
     trace: (formatter: any, ...args: any[]) => void
   }
 
+export type QUICHE_LOG_OFF = -1
+export type QUICHE_LOG_INFO = 0
+export type QUICHE_LOG_WARNING = 1
+export type QUICHE_LOG_ERROR = 2
+export type QUICHE_LOG_FATAL = 3
+export type QUICHE_LOG = QUICHE_LOG_OFF | QUICHE_LOG_INFO | QUICHE_LOG_WARNING | QUICHE_LOG_ERROR | QUICHE_LOG_FATAL
+
   export interface HttpWebTransportInit extends WebTransportOptions {
     host: string
     port: string | number
-    quicheLogVerbose?: 1 | 2 | 3
+    quicheLogVerbose?: QUICHE_LOG
     forceIpv6?: boolean
     localPort?: number
   }


### PR DESCRIPTION
The valid values [are](https://fuchsia.googlesource.com/third_party/abseil-cpp/+/refs/tags/20230125.3/absl/base/log_severity.h#69) -1 | 0 | 1 | 2 | 3 so cause a type error if anything else is passed.