### PR TITLE
feat: support query strings

### DIFF
--- a/main/lib/http2/node/server.js
+++ b/main/lib/http2/node/server.js
@@ -140,7 +140,8 @@ export class Http2WebTransportServer {
         while (path.length > 1 && path[0] === '/' && path[1] === '/') {
           path = path?.slice(1)
         }
-        if (this.paths[path]) {
+        const pathWithoutQuery = path.split('?')[0]
+        if (this.paths[pathWithoutQuery]) {
           this.sendHttp1Headers({ stream, header, protocol: websocketProt })
             .then(() => {
               const retObj = {
@@ -245,7 +246,8 @@ export class Http2WebTransportServer {
       while (path.length > 1 && path[0] === '/' && path[1] === '/') {
         path = path?.slice(1)
       }
-      if (this.paths[path]) {
+      const pathWithoutQuery = path.split('?')[0]
+      if (this.paths[pathWithoutQuery]) {
         const {
           0x2b65: remoteBidirectionalStreams = undefined,
           0x2b64: remoteUnidirectionalStreams = undefined,

--- a/main/lib/session.js
+++ b/main/lib/session.js
@@ -606,3 +606,18 @@ export class HttpWTSession {
     this.state = 'draining'
   }
 }
+
+export class HttpWTServerSession extends HttpWTSession {
+  /**
+   * @param {object} args
+   * @param {import('./types').NativeHttpWTSession} [args.object]
+   * @param {HttpServer | HttpClient} args.parentobj
+   * @param {any | undefined} [args.header= undefined]
+   * @param {string} args.url
+   */
+  constructor(args) {
+    super(args)
+
+    this.url = args.url
+  }
+}

--- a/main/lib/types.ts
+++ b/main/lib/types.ts
@@ -266,6 +266,10 @@ export interface WebTransportSessionImpl extends WebTransportSession {
   state: WebTransportSessionState
 }
 
+export interface WebTransportServerSessionImpl extends WebTransportSessionImpl {
+  url: string
+}
+
 export type QUICHE_LOG_OFF = -1
 export type QUICHE_LOG_INFO = 0
 export type QUICHE_LOG_WARNING = 1

--- a/main/lib/webtransport.browser.js
+++ b/main/lib/webtransport.browser.js
@@ -61,9 +61,11 @@ export class WebTransportPonyfill extends WebTransportBase {
    * @param{{client: HttpClient, sessionint: HttpWTSession, ourl: URL}} args
    */
   startUpConnection({ client, sessionint, ourl }) {
+    const path = `${ourl.pathname}${ourl.search ?? ''}`
+
     client
-      .handleConnection({ createTransport: true, path: ourl.pathname })
-      .then(() => client.createWTSession(sessionint, ourl.pathname))
+      .handleConnection({ createTransport: true, path })
+      .then(() => client.createWTSession(sessionint, path))
       .catch((error) => {
         client.closeHookSession()
         sessionint.readyReject(error)

--- a/main/lib/webtransport.node.js
+++ b/main/lib/webtransport.node.js
@@ -75,17 +75,19 @@ export class WebTransport extends WebTransportBase {
    * @param{{client: HttpClient, sessionint: HttpWTSession, ourl: URL}} args
    */
   startUpConnection({ client, sessionint, ourl }) {
+    const path = `${ourl.pathname}${ourl.search ?? ''}`
+
     client
-      .handleConnection({ createTransport: true, path: ourl.pathname })
-      .then(() => client.createWTSession(sessionint, ourl.pathname))
+      .handleConnection({ createTransport: true, path })
+      .then(() => client.createWTSession(sessionint, path))
       .catch((error) => {
         if (client.transportIntSwitchToReliable) {
           log('Connecting to unreliable failed:', error)
           log('Now switching to reliable')
           client.transportIntSwitchToReliable()
           client
-            .handleConnection({ createTransport: false, path: ourl.pathname })
-            .then(() => client.createWTSession(sessionint, ourl.pathname))
+            .handleConnection({ createTransport: false, path })
+            .then(() => client.createWTSession(sessionint, path))
             .catch((error) => {
               client.closeHookSession()
               sessionint.readyReject(error)

--- a/main/test/fixtures/server.js
+++ b/main/test/fixtures/server.js
@@ -310,6 +310,18 @@ export async function createServer() {
             }
           },
 
+          // support query strings
+          async () => {
+            for await (const session of getReaderStream(
+              server.sessionStream('/session_with_query')
+            )) {
+              await session.close({
+                closeCode: 0,
+                reason: `session.url=${session.url}`
+              })
+            }
+          },
+
           // send data over unidirectional stream, initiated by remote
           async () => {
             for await (const session of getReaderStream(

--- a/main/test/session.spec.js
+++ b/main/test/session.spec.js
@@ -82,6 +82,22 @@ describe('session', function () {
     expect(result).to.have.property('closeCode', 7)
     expect(result).to.have.property('reason', 'this is the reason')
   })
+
+  it('should connect to a path with a query in the URL', async () => {
+    client = new WebTransport(
+      `${process.env.SERVER_URL}/session_with_query?foo=bar`,
+      wtOptions
+    )
+    await client.ready
+
+    const result = await client.closed
+    expect(result).to.have.property('closeCode', 0)
+    expect(result).to.have.property(
+      'reason',
+      'session.url=/session_with_query?foo=bar'
+    )
+  })
+
   if (browser === 'firefox') this.timeout(31000) // really firefox?
   it('should error when connecting to a server that does not exist', async () => {
     client = new WebTransport(`https://127.0.0.1:39821`, {

--- a/transports/http3-quiche/src/http3serverbackend.cc
+++ b/transports/http3-quiche/src/http3serverbackend.cc
@@ -43,6 +43,19 @@ namespace quic
   }
   */
 
+  std::string Http3ServerBackend::removeQuery(std::string const& s)
+   {
+    std::string::size_type pos = s.find('?');
+    if (pos != std::string::npos)
+    {
+        return s.substr(0, pos);
+    }
+    else
+    {
+        return s;
+    }
+  }
+
   Http3ServerBackend::WebTransportRespPromisePtr
   Http3ServerBackend::ProcessWebTransportRequest(
       const spdy::Http2HeaderBlock &request_headers,
@@ -66,8 +79,9 @@ namespace quic
       return promise;
     }
     std::string path(path_it->second);
+    std::string pathWithoutQuery = removeQuery(path);
 
-    if (paths_.find(path) != paths_.end())
+    if (paths_.find(pathWithoutQuery) != paths_.end())
     { // to do handle our web transport paths
       std::unique_ptr<WebTransportResponse> response = std::make_unique<WebTransportResponse>();
       Http3WTSession *wtsession = new Http3WTSession();

--- a/transports/http3-quiche/src/http3serverbackend.h
+++ b/transports/http3-quiche/src/http3serverbackend.h
@@ -89,6 +89,7 @@ namespace quic
     Http3Server *server_; // unowned
     bool jshandlerequesthandler_;
     std::set<std::string> paths_;
+    std::string removeQuery(std::string const& s);
   };
 
 } // namespace quic


### PR DESCRIPTION
Adds support for creating WebTransport session with URLs that include query strings:

```js
const wt = new WebTransport('https://example.com/some-endpoint?foo=bar')
```

...and also accessing the path via the `.url` property which is consistent with Node http/http2 requests

```js
const sessionReader = server.sessionStream('/some-endpoint').getReader()
const { value: session } = await sessionReader.read()

console.info(session.url)
// /some-endpoint?foo=bar
```

Fixes #279