### PR TITLE
fix(types): fix typescript types not being found

### DIFF
--- a/main/package.json
+++ b/main/package.json
@@ -5,12 +5,12 @@
   "exports": {
     ".": {
       "node": {
-        "import": "./lib/index.node.js",
-        "types": "./dist/lib/index.node.d.ts"
+        "types": "./dist/lib/index.node.d.ts",
+        "import": "./lib/index.node.js"
       },
       "browser": {
-        "import": "./lib/index.browser.js",
-        "types": "./dist/lib/index.browser.d.ts"
+        "types": "./dist/lib/index.browser.d.ts",
+        "import": "./lib/index.browser.js"
       }
     }
   },

--- a/main/package.json
+++ b/main/package.json
@@ -4,8 +4,14 @@
   "description": "A component to add webtransport support (server and client) to node.js using libquiche",
   "exports": {
     ".": {
-      "node": "./lib/index.node.js",
-      "browser": "./lib/index.browser.js"
+      "node": {
+        "import": "./lib/index.node.js",
+        "types": "./dist/lib/index.node.d.ts"
+      },
+      "browser": {
+        "import": "./lib/index.browser.js",
+        "types": "./dist/lib/index.browser.d.ts"
+      }
     }
   },
   "engines": {


### PR DESCRIPTION
Hi, I'm working on an exploration project about new things, and ran into the following issue:

<img width="1722" alt="image" src="https://github.com/fails-components/webtransport/assets/300791/d2ac7006-fcd7-4696-a599-a88b4fc7b6c2">

This commit adds the missing types to the package.json file so that typescript can find them. This fixes the following error:

```sh
[Running: npx tsc]
server/server.ts:7:29 - error TS7016: Could not find a declaration file for module '@fails-components/webtransport'. '/Users/mikavilpas/git/webtransport/main/lib/index.node.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/fails-components__webtransport` if it exists or add a new declaration (.d.ts) file containing `declare module '@fails-components/webtransport';`

7 import { Http3Server } from "@fails-components/webtransport"
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
```