### PR TITLE
Fix http2 rtt and flow control

### DIFF
--- a/main/lib/http2/node/server.js
+++ b/main/lib/http2/node/server.js
@@ -95,7 +95,7 @@ export class Http2WebTransportServer {
       let rtt = 100
       let adjust = 1
       // ok we got a session and want to measure RTT
-      let pingsender = setInterval(() => {
+      const pingupdater = () => {
         if (!session.closed)
           // eslint-disable-next-line no-unused-vars
           session.ping((err, duration, payload) => {
@@ -111,7 +111,9 @@ export class Http2WebTransportServer {
           // @ts-ignore
           pingsender = undefined
         }
-      }, 1000)
+      }
+      let pingsender = setInterval(pingupdater, 1000)
+      pingupdater()
 
       session.on('close', () => {
         if (pingsender) clearInterval(pingsender)

--- a/main/lib/http2/session.js
+++ b/main/lib/http2/session.js
@@ -306,16 +306,19 @@ export class Http2WebTransportSession {
   }
 
   smoothedRtt() {
+    let toret
     if (this.stream) {
       // we are on node
       // @ts-ignore
-      return this.stream.session?.WTrtt || 26
+      toret = this.stream.session?.WTrtt || 25
     } else if (this.ws) {
       // we are at the Browser, so we use the connection rtt?
       // @ts-ignore
       // eslint-disable-next-line no-undef
-      return navigator?.connection?.rtt || 26
+      toret = navigator?.connection?.rtt || 25
     }
+    toret = Math.ceil(toret / 25) * 25 // to do be to accurate!
+    return toret
   }
 
   /**

--- a/test/sendorder.spec.js
+++ b/test/sendorder.spec.js
@@ -112,7 +112,6 @@ describe('sendgroup streams', function () {
   })
 
   it('sends data over two outgoing bidirectional streams with different priority (10 MB)', async function () {
-    this.timeout(10000)
     // suggested by vvasiliev
     // client context - connects to the server, opens a uni stream, sends some data and reads the response
     try {


### PR DESCRIPTION
RTT values for flow control did not work immediately in tests.
Also, values below 25 ms are not useful for controlling the flow control window.