### PR TITLE
Initial parameters and ws fixes

### DIFF
--- a/main/lib/http2/browser/browserparser.js
+++ b/main/lib/http2/browser/browserparser.js
@@ -285,4 +285,8 @@ export class BrowserParser extends ParserBase {
   closeHttp2Stream(code) {
     this.ws.close(1000)
   }
+
+  initialParametersMandatory() {
+    return true
+  }
 }

--- a/main/lib/http2/node/capsuleparser.js
+++ b/main/lib/http2/node/capsuleparser.js
@@ -337,4 +337,8 @@ export class Http2CapsuleParser extends ParserBaseHttp2 {
     this.stream.close(code)
     this.stream.destroy()
   }
+
+  initialParametersMandatory() {
+    return false
+  }
 }

--- a/main/lib/http2/node/websocketparser.js
+++ b/main/lib/http2/node/websocketparser.js
@@ -876,4 +876,8 @@ export class WebSocketParser extends ParserBaseHttp2 {
     } else if (stream.end) stream.end()
     else throw new Error('http2:session not close method')
   }
+
+  initialParametersMandatory() {
+    return true
+  }
 }

--- a/main/lib/http2/node/websocketparser.js
+++ b/main/lib/http2/node/websocketparser.js
@@ -458,7 +458,7 @@ export class WebSocketParser extends ParserBaseHttp2 {
               let wbufferstate
               if (
                 type !== ParserBase.WT_STREAM_WOFIN ||
-                type !== ParserBase.WT_STREAM_WOFIN
+                type !== ParserBase.WT_STREAM_WFIN
               ) {
                 if (fin) {
                   wbufferstate = bufferstate

--- a/main/lib/http2/parserbase.js
+++ b/main/lib/http2/parserbase.js
@@ -83,6 +83,14 @@ export class ParserBase {
   }
 
   /**
+   * @abstract
+   * @return{boolean}
+   */
+  initialParametersMandatory() {
+    throw new Error('Implement initialParametersMandatory in derived Class')
+  }
+
+  /**
    * @param{{code: Number, reason: string}}arg
    */
   sendClose({ code, reason }) {

--- a/main/lib/http2/session.js
+++ b/main/lib/http2/session.js
@@ -109,9 +109,20 @@ export class Http2WebTransportSession {
   }
 
   sendInitialParameters() {
-    this.flowController.sendWindowUpdate()
-    this.streamIdMngrBi.sendMaxStreamsFrameInitial()
-    this.streamIdMngrUni.sendMaxStreamsFrameInitial()
+    let skip = false //skips the initial parameters at environment with settings
+    if (process) {
+      if (process.version) {
+        const majorVersion = parseInt(
+          process.version.split('.')[0].substring(1)
+        )
+        if (majorVersion >= 20) skip = true
+      }
+    }
+    if (!skip || this.capsParser.initialParametersMandatory()) {
+      this.flowController.sendWindowUpdate()
+      this.streamIdMngrBi.sendMaxStreamsFrameInitial()
+      this.streamIdMngrUni.sendMaxStreamsFrameInitial()
+    }
   }
 
   drainWrites() {


### PR DESCRIPTION
There is no need to send out initial capsules if the node supports HTTP/2 custom settings.
Furthermore, there was an obvious typo in the websocket code.