### PR TITLE
Update client cert cahin verifier (still experimental)

### DIFF
--- a/test/session.spec.js
+++ b/test/session.spec.js
@@ -173,6 +173,25 @@ describe('session', function () {
     await client.closed
   })
 
+  it('should error when connecting with a bad certificate (non serverCertificateHashes)', async () => {
+    client = new WebTransport(`${process.env.SERVER_URL}/session_close`, {
+      // @ts-ignore
+      forceReliable
+    })
+
+    const [closedResult, readyResult] = await Promise.all([
+      client.closed.catch((err) => err),
+      client.ready.catch((err) => err)
+    ])
+
+    expect(closedResult)
+      .to.be.a('WebTransportError')
+      .with.property('message', handshakemess)
+    expect(readyResult)
+      .to.be.a('WebTransportError')
+      .with.property('message', handshakemess)
+  })
+
   if (
     process.env.USE_POLYFILL !== 'true' &&
     process.env.USE_PONYFILL !== 'true' &&

--- a/transports/http3-quiche/src/http3client.cc
+++ b/transports/http3-quiche/src/http3client.cc
@@ -91,12 +91,14 @@ namespace quic
                 retObj.Set("hostname", hostname);
                 retObj.Set("port", port);
                 retObj.Set("serverconfig", server_config);
-                // todo certs
 
                 Napi::Array jscerts = Napi::Array::New(env, certs.size());
                 for (size_t i = 0; i < certs.size(); i++) {
-                    jscerts.Set(i, certs[i]);
+                    jscerts.Set(i, Napi::Buffer<uint8_t>::Copy(env,
+                            reinterpret_cast<const uint8_t*>(certs[i].data()),
+                             certs[i].size()));
                 }
+                retObj.Set("certs", jscerts);
                 retObj.Set("signature", signature);
 
                 Napi::Value verifyres = env.Global().Get("FAILSVerifyProof").As<Napi::Function>().Call({
@@ -125,13 +127,15 @@ namespace quic
 
                 Napi::Array jscerts = Napi::Array::New(env, certs.size());
                 for (size_t i = 0; i < certs.size(); i++) {
-                    jscerts.Set(i, certs[i]);
+                    jscerts.Set(i, Napi::Buffer<uint8_t>::Copy(env,
+                            reinterpret_cast<const uint8_t*>(certs[i].data()),
+                             certs[i].size()));
                 }
+                retObj.Set("certs", jscerts);
                 Napi::Value verifyres = env.Global().Get("FAILSVerifyProof").As<Napi::Function>().Call({
                     retObj });
                 if (verifyres.As<Napi::Boolean>().Value()) {
                     return QUIC_SUCCESS;
-
                 } else {
                     return QUIC_FAILURE;
                 }


### PR DESCRIPTION
This adds some fixes to node client certificate validation, so that it may work.
However, this is not thoroughly tested and is not covered by automated tests. If it is broken, it poses a security risk; therefore, a warning is issued that it may be broken and should not be used in production.

Fixes #391
