### PR TITLE
Very minor. Add space after "reason" in session.js

### DIFF
--- a/main/lib/session.js
+++ b/main/lib/session.js
@@ -590,7 +590,7 @@ export class HttpWTSession {
     const wtError = new WebTransportError(
       `Session closed (on process ${pid}) with code ` +
         args.errorcode +
-        ' and reason' +
+        ' and reason ' +
         args.error
     )
 


### PR DESCRIPTION
Very minor. Add space after "reason".