### PR TITLE
If this.socketInt.getSendQueueCount is undefined define function that returns 0; support Deno

### DIFF
--- a/transports/http3-quiche/lib/clientsocket.js
+++ b/transports/http3-quiche/lib/clientsocket.js
@@ -41,6 +41,10 @@ export class Http3WebTransportClientSocket extends Http3WebTransportSocket {
           ipv6Only: this.forceIpv6
         })
 
+        if (!this.socketInt.getSendQueueCount) {
+          this.socketInt.getSendQueueCount = function() { return 0 }
+        }
+
         this.socketInt.on('error', (evt) => {
           this.jsobj.onClientError({ errorcode: 100, error: evt.toString() })
         })

--- a/transports/http3-quiche/lib/serversocket.js
+++ b/transports/http3-quiche/lib/serversocket.js
@@ -32,6 +32,10 @@ export class Http3WebTransportServerSocket extends Http3WebTransportSocket {
           type: result.family === 4 ? 'udp4' : 'udp6'
         })
 
+        if (!this.socketInt.getSendQueueCount) {
+          this.socketInt.getSendQueueCount = function() { return 0 }
+        }
+
         this.socketInt.on('listening', () => {
           const addr = this.socketInt.address()
           const retObj = {


### PR DESCRIPTION
Fixes https://github.com/fails-components/webtransport/issues/409